### PR TITLE
display all output when done

### DIFF
--- a/tape.go
+++ b/tape.go
@@ -179,7 +179,8 @@ func (tape *Tape) TotalCount() int {
 	return len(tape.vertexes)
 }
 
-// Close marks the Tape as done. (This currently has no effect.)
+// Close marks the Tape as done, which tells it to display all vertex output
+// for the final render.
 func (tape *Tape) Close() error {
 	tape.l.Lock()
 	tape.done = true
@@ -317,7 +318,7 @@ func (tape *Tape) Render(w io.Writer, u *UI) error {
 			groups = groups.AddVertex(w, u, tape.groups, vtx, haveInput)
 		}
 
-		if tape.showAllOutput || vtx.Completed == nil || vtx.Error != nil {
+		if tape.done || tape.showAllOutput || vtx.Completed == nil || vtx.Error != nil {
 			term := tape.vertexLogs(vtx.Id)
 
 			if vtx.Error != nil {
@@ -329,6 +330,10 @@ func (tape *Tape) Render(w io.Writer, u *UI) error {
 			buf := new(bytes.Buffer)
 			groups.TermPrefix(buf, u, vtx)
 			term.SetPrefix(buf.String())
+
+			if tape.done {
+				term.SetHeight(term.UsedHeight())
+			}
 
 			if err := u.RenderTerm(w, term); err != nil {
 				return err

--- a/tape_test.go
+++ b/tape_test.go
@@ -95,6 +95,13 @@ func TestSingleCompleted(t *testing.T) {
 		runningVtx(recorder, "a", "vertex a").Done(nil)
 		testGolden(t, tape)
 	})
+	t.Run("done", func(t *testing.T) {
+		tape := progrock.NewTape()
+		recorder := progrock.NewRecorder(tape)
+		runningVtx(recorder, "a", "vertex a").Done(nil)
+		tape.Close()
+		testGolden(t, tape)
+	})
 }
 
 func TestSingleRunningTasks(t *testing.T) {

--- a/testdata/TestSingleCompleted/done.golden
+++ b/testdata/TestSingleCompleted/done.golden
@@ -1,0 +1,6 @@
+[32m█[0m [90m[0.00s][0m vertex a
+[32m┃[0m stdout 1                                                                      [0m
+[32m┃[0m stderr 1                                                                      [0m
+[32m┃[0m stdout 2                                                                      [0m
+[32m┃[0m stderr 2                                                                      [0m
+[32m┻[0m 


### PR DESCRIPTION
This seems like the most useful balance: we'll still collapse successful entries to keep the UI tidy when live, but then display all output for the final render.