### PR TITLE
Make writer field of RPCReceiver public.

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -45,7 +45,7 @@ func (w *RPCWriter) Close() error {
 }
 
 type RPCReceiver struct {
-	w Writer
+	W Writer
 
 	UnimplementedProgressServiceServer
 }
@@ -59,7 +59,7 @@ func (recv *RPCReceiver) WriteUpdates(srv ProgressService_WriteUpdatesServer) er
 			}
 			return err
 		}
-		if err := recv.w.WriteStatus(update); err != nil {
+		if err := recv.W.WriteStatus(update); err != nil {
 			return err
 		}
 	}
@@ -67,7 +67,7 @@ func (recv *RPCReceiver) WriteUpdates(srv ProgressService_WriteUpdatesServer) er
 
 func ServeRPC(l net.Listener, w Writer) (Writer, error) {
 	recv := &RPCReceiver{
-		w: w,
+		W: w,
 	}
 
 	srv := grpc.NewServer()


### PR DESCRIPTION
Need this in Dagger to create an implementation of buildkit session attachable that wraps RPCReceiver.

@vito here's where it's used in the session frontend PR: https://github.com/dagger/dagger/pull/5415/commits/22af8f09bbfd2b3094c76530e9a31896153615a7#diff-a92e280e12097c7a058672dc80551529f7dfed8e9001beeff1109d518a0e89d0R422-R450

Kind of neat in that because progrock uses grpc, we can just directly attach the client/server over the session's grpc conn and forward events from graphql server back to client(s).