### PR TITLE
fix: ensure that NewOutput always assumes a TTY

### DIFF
--- a/ui/output.go
+++ b/ui/output.go
@@ -17,6 +17,7 @@ import (
 func NewOutput(w io.Writer, opts ...termenv.OutputOption) *termenv.Output {
 	return termenv.NewOutput(w, append([]termenv.OutputOption{
 		termenv.WithProfile(ColorProfile()),
+		termenv.WithTTY(true),
 	}, opts...)...)
 }
 


### PR DESCRIPTION
See https://github.com/dagger/dagger/pull/7070. This replaces https://github.com/dagger/dagger/issues/7047.

The description of this function currently lies. Without this, the `isTTY` function in `termenv` will return `false`, so we never get colors. 